### PR TITLE
feat: add `popoverProps` for customization need

### DIFF
--- a/src/ResponsiveAntMenu.js
+++ b/src/ResponsiveAntMenu.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { number, string, func, oneOfType, bool, oneOf } from 'prop-types';
+import { number, string, func, oneOfType, bool, oneOf, object } from 'prop-types';
 import { Popover } from 'antd';
 import throttle from 'lodash.throttle';
 
 const ResponsiveAntMenu = (props) => {
     const {
-        children: MenuMarkup, activeLinkKey, menuClassName: className,
+        children: MenuMarkup, activeLinkKey, menuClassName: className, popoverProps,
         theme, mode, mobileMenuContent, placement, popoverTrigger,
         throttleViewportChange, mobileBreakPoint, closeOnClick
     } = props;
@@ -39,6 +39,7 @@ const ResponsiveAntMenu = (props) => {
             placement={placement}
             visible={isMenuShown}
             onVisibleChange={setIsMenuShown}
+            {...popoverProps}
         >
             {mobileMenuContent(isMenuShown)}
         </Popover> : menuToRender;
@@ -58,6 +59,7 @@ ResponsiveAntMenu.propTypes = {
     ]),
     mobileMenuContent: func.isRequired,
     menuClassName: string,
+    popoverProps: object,
     popoverTrigger: oneOf(['click', 'hover', 'focus'])
 };
 


### PR DESCRIPTION
feat: Add `popoverProps` for customization needs

This PR adds the `popoverProps` prop to the `ResponsiveAntMenu` component, allowing for further customization of the Popover component used in the menu. This prop accepts an object and spreads it onto the Popover component, providing flexibility for various customization needs.

_Generated using [OpenSauced](https://opensauced.ai/)._